### PR TITLE
Change matching criteria to longest-match instead of earliest-match

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2016, Rigetti & Co, Inc.
+Copyright (c) 2016-2018, Rigetti & Co, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The `alexa` package exports a single macro: `define-string-lexer`. You can view 
 (format t "~A"
         (documentation 'alexa:define-string-lexer
                        'function))
-``` 
+```
 
 ALEXA may be used with parsing libraries such as [`cl-yacc`](https://www.irif.univ-paris-diderot.fr/~jch/software/cl-yacc/).
 
@@ -18,11 +18,16 @@ ALEXA may be used with parsing libraries such as [`cl-yacc`](https://www.irif.un
 
 ALEXA has a few unique features to make lexical analysis easier. These include:
 
-* Bound variables `$<` and `$>` to determine the start and end of your matches.
+* Bound variables `$<` and `$>` to determine the start and end of your matches. The value of `(- $> $<)` is equal to the length of the match.
 * Bound variables to matches on named registers. For example, `(?<DIGIT>\d)` will match a digit, and bind it in your Lisp code to the lexical variable `$DIGIT`.
 * Regex aliases. You don't need to re-type `[A-Za-z][A-Za-z0-9_]` for each identifier. You can instead define the alias `(:ident "[A-Za-z][A-Za-z0-9_]")` and use `{{IDENT}}` in your lexical rules.
+* Eager matching. Normally ALEXA looks for the longest match. For optimization, you may decide to execute an action if a match succeeds. This can be done by declaring a regular expression as `EAGER`.
+
+ALEXA has been written with efficiency in mind. Generated lexers will avoid consing in most cases, unless you use the `$@` variable which expands into a `SUBSEQ` call on the string.
 
 ## Example
+
+### Arithmetic Expression Tokenization
 
 The following simple example shows how to tokenize simple arithmetic expressions. First, we define what a token is and how to make one.
 
@@ -44,6 +49,7 @@ Next, we define the lexer. We create two aliases `:num` and `:name` to make our 
   "Make a lexical analyzer for arithmetic expressions."
   ((:num "\\d+")
    (:name "[A-Za-z][A-Za-z0-9_]*"))
+  ("pi"       (return (tok :number pi)))
   ("{{NAME}}" (return (tok :variable (intern $@))))
   ("{{NUM}}"  (return (tok :number (parse-integer $@))))
   ("[+*/-]"   (return (tok :operator (intern $@ 'keyword))))
@@ -75,7 +81,7 @@ Calling `lex-line` on arithmetic expressions now gives us our expected results.
  (:RIGHT-PAREN)
  (:OPERATOR . :/)
  (:VARIABLE . |z|))
- 
+
 > (lex-line "1/(1/R_1 + 1/R_2)")
 ((:NUMBER . 1)
  (:OPERATOR . :/)
@@ -90,6 +96,93 @@ Calling `lex-line` on arithmetic expressions now gives us our expected results.
  (:RIGHT-PAREN))
 ```
 
+In our lexer, we have `pi` as the rule for one of the lexical actions. ALEXA will generate code to correctly identify it. ALEXA follows the rule of matching the longest string possible, breaking ties depending on the order of the rules stated in the lexer's definition. In the following example, we have both `pi` and `pip`. Even though two rules match `pi`, the first one breaks the tie and we correctly resolve it to `3.141...`. Similarly, the lexer matches `pip` against the correct rule because it was the longest match.
+
+```
+> (lex-line "pi+2*pip")
+
+((:NUMBER . 3.141592653589793d0)
+ (:OPERATOR . :+)
+ (:NUMBER . 2)
+ (:OPERATOR . :*)
+ (:VARIABLE . |pip|))
+```
+
+Note that ALEXA has no notion of "specificity". If the rules for `pi` and `{{NAME}}` were flipped, then `{{NAME}}` would always supersede `pi`.
+
+### Eager Matching
+
+In our arithmetic expression lexer, we can optimize the lexing process. If we match against any of the latter six rules, then we know the match is unambiguous and we can fire the rule. ALEXA is very conservative, and has no idea about this. You can tell ALEXA that this is the case by declaring said rules as `EAGER`. In addition, we can re-order the rules favorably. We get the equivalent lexer:
+
+```
+(alexa:define-string-lexer arith-lexer-opt
+  "Make a lexical analyzer for arithmetic expressions."
+  ((:num "\\d+")
+   (:name "[A-Za-z][A-Za-z0-9_]*"))
+  ((eager "{{NUM}}")  (return (tok :number (parse-integer $@))))
+  ((eager "[+*/-]")   (return (tok :operator (intern $@ 'keyword))))
+  ((eager "\\(")      (return (tok :left-paren)))
+  ((eager "\\)")      (return (tok :right-paren)))
+  ((eager "\\s+")     nil)
+  ("pi"               (return (tok :number pi)))
+  ((eager "{{NAME}}") (return (tok :variable (intern $@)))))
+```
+
+As a microbenchmark, we generate random strings of tokenizable content.
+
+```
+(defun lex (lexer)
+  (loop :for tok := (funcall lexer)
+        :while tok
+          :collect tok))
+
+(defun random-word ()
+  (substitute #\_ #\- (format nil "~R" (random 1000))))
+
+(defun random-expr (n)
+  (with-output-to-string (s)
+    (loop :repeat n :do
+      (alexandria:whichever
+       (format s "~D" (random most-positive-fixnum))
+       (format s "~C" (alexandria:random-elt "+-*/"))
+       (write-string "pi " s)
+       (write-string (random-word) s)
+       (format s "(")
+       (format s ")")
+       (loop :repeat (random 8) :do (write-char #\Space s))))))
+
+(defun test (&optional (string (random-expr 1000000)))
+  (format t "Length of string: ~D~%" (length string))
+  (let ((l (arith-lexer string))
+        (lo (arith-lexer-opt string)))
+    (sb-ext:gc :full t)
+    (time (lex l))
+    (sb-ext:gc :full t)
+    (time (lex lo))
+    nil))
+```
+
+Calling `test` on `SBCL 1.4.7.192-8b8c9bcc0` gives results like
+
+```
+Length of string: 7037267
+Evaluation took:
+  2.276 seconds of real time
+  2.276657 seconds of total run time (2.274266 user, 0.002391 system)
+  100.04% CPU
+  6,357,950,986 processor cycles
+  0 bytes consed
+
+Evaluation took:
+  1.571 seconds of real time
+  1.572094 seconds of total run time (1.570309 user, 0.001785 system)
+  100.06% CPU
+  4,389,463,410 processor cycles
+  0 bytes consed
+```
+
+In this example, we reduce the runtime by about 31%.
+
 ## Contributing
 
 If you have suggestions or questions, please file an issue in GitHub. If you have any bug fixes or improvements, please make a pull request.
@@ -98,4 +191,4 @@ If you have suggestions or questions, please file an issue in GitHub. If you hav
 
 This software is released under the BSD 3-clause license. See `LICENSE.txt` for details.
 
-Copyright © 2016 Rigetti Computing
+Copyright © 2016–2018 Rigetti Computing

--- a/alexa-tests.asd
+++ b/alexa-tests.asd
@@ -1,0 +1,20 @@
+;;;; alexa-tests.asd
+;;;;
+;;;; Author: Robert Smith
+;;;;
+;;;; Copyright (c) 2018 Rigetti & Co, Inc.
+
+(asdf:defsystem #:alexa-tests
+  :description "Regression tests for ALEXA."
+  :author "Robert Smith <robert@rigetti.com>"
+  :license "BSD 3-clause (See LICENSE.txt)"
+  :depends-on (#:alexa
+               #:fiasco
+               #:uiop)
+  :perform (asdf:test-op (o s)
+                         (uiop:symbol-call ':alexa-tests
+                                           '#:run-alexa-tests))
+  :serial t
+  :components ((:module tests
+                :serial t
+                :components ((:file "tests")))))

--- a/alexa.asd
+++ b/alexa.asd
@@ -11,6 +11,7 @@
   :version (:read-file-form "VERSION.txt")
   :depends-on (#:alexandria
                #:cl-ppcre)
+  :in-order-to ((asdf:test-op (asdf:test-op #:alexa-tests)))
   :serial t
   :components ((:static-file "LICENSE.txt")
                (:module src

--- a/alexa.asd
+++ b/alexa.asd
@@ -2,7 +2,7 @@
 ;;;;
 ;;;; Author: Robert Smith
 ;;;;
-;;;; Copyright (c) 2016 Rigetti & Co, Inc.
+;;;; Copyright (c) 2016-2018 Rigetti & Co, Inc.
 
 (asdf:defsystem #:alexa
   :description "A lexical analyzer generator."

--- a/src/alexa.lisp
+++ b/src/alexa.lisp
@@ -4,6 +4,9 @@
 
 (in-package #:alexa)
 
+(deftype non-negative-fixnum ()
+  `(and fixnum unsigned-byte))
+
 (defun walk-tree (f tree)
   (labels ((walk-tree (tree)
              (cond ((atom tree)
@@ -28,6 +31,7 @@
 
 (defstruct pattern
   regex
+  short-circuit-p
   parse-tree
   num-registers
   register-names
@@ -42,49 +46,113 @@
     (loop :for i :from 1 :to (pattern-num-registers pat)
           :collect (alexandria:format-symbol package "$~A" (register-name i)))))
 
-(defun generate-pattern (pat continue-tag string-var start-var end-var)
-  (alexandria:with-gensyms (match-start match-end
-                            reg-start reg-starts reg-ends
-                            pattern-block)
-    `(block ,pattern-block
-       (multiple-value-bind (,match-start ,match-end ,reg-starts ,reg-ends)
-           (cl-ppcre:scan ',(pattern-parse-tree pat) ,STRING-VAR :start ,START-VAR
-                                                                 :end ,END-VAR)
-         (declare (ignorable ,reg-starts ,reg-ends))
-         ;; No match
-         (when (null ,match-start)
-           (return-from ,pattern-block))
+(defun empty-match-error (regex)
+  (error "Empty match on pattern ~S. This will cause infinite looping." regex))
 
-         ;; Empty match.
-         (when (= ,match-start ,match-end)
-           (error "Empty match on pattern ~S. This will cause infinite looping."
-                  ',(pattern-regex pat)))
+(defmacro let-lazy (bindings &body body)
+  (let* ((storage-variables (loop :for binding :in bindings
+                                  :collect (gensym (symbol-name (first binding)))))
+         (sentinel (gensym "SENTINEL")))
+    `(let ,(loop :for var :in storage-variables :collect `(,var ',sentinel))
+       (declare (ignorable ,@storage-variables))
+       (symbol-macrolet ,(loop :for sv :in storage-variables
+                               :for (name form) :in bindings
+                               ;; If LET-LAZY were a more general
+                               ;; utility outside of ALEXA, then we
+                               ;; might opt to stash each FORM into a
+                               ;; function, and call the function here
+                               ;; to reduce code size. However, it's
+                               ;; unlikely that lexer rules will
+                               ;; reference these lazy variables often
+                               ;; enough for that to be a concern.
+                               :collect `(,name (if (eq ',sentinel ,sv)
+                                                    (setf ,sv ,form)
+                                                    ,sv)))
+         ,@body))))
 
-         ;; We have a match. Bind the standard symbols $@ $< $>, and
-         ;; set up bindings for the register matches.
-         ,(let ((reg-vars (pattern-register-variables pat *package*))
-                ($@ (intern "$@" *package*))
-                ($< (intern "$<" *package*))
-                ($> (intern "$>" *package*)))
-            `(let ((,$@ (subseq ,STRING-VAR ,MATCH-START ,MATCH-END))
-                   (,$< ,START-VAR)
-                   (,$> ,END-VAR)
-                   ,@(loop :for i :from 0
-                           :for reg-var :in reg-vars
-                           :collect `(,reg-var (let ((,reg-start (aref ,reg-starts ,i)))
-                                                 (if (null ,reg-start)
-                                                     nil
-                                                     (subseq ,STRING-VAR
-                                                             ,reg-start
-                                                             (aref ,reg-ends ,i)))))))
-               (declare (ignorable ,$@ ,$< ,$> ,@reg-vars))
-               ;; Set the new start for the next iteration.
-               (setq ,START-VAR ,match-end)
-               ;; Execute the pattern code.
-               ,@(pattern-code pat)
-               ;; Assuming the pattern code didn't exit, continue with
-               ;; the lex loop.
-               (go ,CONTINUE-TAG)))))))
+;;; Generate the code used to determine if there is a match.
+(defun generate-pattern-match-code (pat execute-tag
+                                    string-var start-var end-var
+                                    match-start-var match-end-var
+                                    reg-starts-var reg-ends-var
+                                    max-match-length-var match-rule-index-var i)
+  (check-type pat pattern)
+  (check-type execute-tag symbol)
+  (check-type string-var symbol)
+  (check-type start-var symbol)
+  (check-type end-var symbol)
+  (check-type match-start-var symbol)
+  (check-type match-end-var symbol)
+  (check-type reg-starts-var symbol)
+  (check-type reg-ends-var symbol)
+  (check-type max-match-length-var symbol)
+  (check-type match-rule-index-var symbol)
+  (check-type i unsigned-byte)
+  (alexandria:with-gensyms (temp-match-start
+                            temp-match-end
+                            temp-reg-starts
+                            temp-reg-ends)
+    ;; Perform the regex match.
+    `(multiple-value-bind (,temp-match-start ,temp-match-end ,temp-reg-starts ,temp-reg-ends)
+         (cl-ppcre:scan ',(pattern-parse-tree pat) ,string-var :start ,start-var
+                                                               :end ,end-var)
+       ;; Do we have a match? If not, we'll just move on to the next
+       ;; thing to match.
+       (if (null ,temp-match-start)
+           nil
+           (locally (declare (type non-negative-fixnum ,temp-match-start ,temp-match-end))
+             (cond
+               ;; Empty match. This could be a user bug.
+               ((= ,temp-match-start ,temp-match-end)
+                (empty-match-error ',(pattern-regex pat)))
+
+               ;; We have a match, but we need to see if it's the longest
+               ;; match we've seen so far.
+               ((< ,max-match-length-var (- ,temp-match-end ,temp-match-start))
+                ;; Record this is the best we got so far.
+                (setq ,max-match-length-var (- ,temp-match-end ,temp-match-start)
+                      ,match-rule-index-var ,i
+                      ,match-start-var      ,temp-match-start
+                      ,match-end-var        ,temp-match-end
+                      ,reg-starts-var       ,temp-reg-starts
+                      ,reg-ends-var         ,temp-reg-ends)
+                ;; Execute immediately if we are going to short circuit.
+                ,(when (pattern-short-circuit-p pat)
+                   `(go ,execute-tag)))))))))
+
+;;; Generate the code used to execute the action of a match.
+(defun generate-pattern-execution-code (pat string-var
+                                        match-start-var match-end-var
+                                        reg-starts-var reg-ends-var)
+  (check-type pat pattern)
+  (check-type string-var symbol)
+  (check-type match-start-var symbol)
+  (check-type match-end-var symbol)
+  (check-type reg-starts-var symbol)
+  (check-type reg-ends-var symbol)
+  (alexandria:with-gensyms (reg-start)
+    (let* ((reg-vars (pattern-register-variables pat *package*))
+           ($@ (intern "$@" *package*))
+           ($< (intern "$<" *package*))
+           ($> (intern "$>" *package*)))
+      `(let ((,$< ,match-start-var)
+             (,$> ,match-end-var))
+         (declare (ignorable ,$< ,$>))
+         ;; We lazy bind these because we don't want to
+         ;; cons up the entire matched string if we
+         ;; don't need to.
+         (let-lazy ((,$@ (subseq ,string-var ,match-start-var ,match-end-var))
+                    ,@(loop :for i :from 0
+                            :for reg-var :in reg-vars
+                            :collect `(,reg-var (let ((,reg-start (aref ,reg-starts-var ,i)))
+                                                  (if (null ,reg-start)
+                                                      nil
+                                                      (subseq ,string-var
+                                                              ,reg-start
+                                                              (aref ,reg-ends-var ,i)))))))
+           (declare (ignorable ,$@ ,@reg-vars))
+           ;; Execute the pattern code.
+           ,@(pattern-code pat))))))
 
 (defun fill-in-aliases (aliases regex)
   (labels ((extract-name-from-match (match)
@@ -116,6 +184,8 @@ Defining a lexical analyzer is actually defining a function named NAME whose lam
 
 The STRING is the string to be analyzed, and START/END are the starting and ending positions to be looked at. Calling the function named NAME will produce a closure which, if called repeatedly, will produce results according to the lexical rules defined. When the input string is exhausted, NIL is returned, and the string will be unbound within the closure to allow garbage collection.
 
+The lexer will fire the action which had the longest match, and ties are broken based on the order of the actions (earlier ones are preferred). This rule can be selectively disabled for a particular action if one declares it to be a short circuiting (see below).
+
 Signals LEXER-MATCH-ERROR as a continuable error if no match was found.
 
 The syntax of BODY is:
@@ -130,16 +200,23 @@ An <alias definition> is a list
 
 The name of the keyword may be used in the <lexical action> regexes. A <lexical action> is a list
 
-    (<regex string> &body <code>)
+    (<pattern spec> &body <code>)
 
-The <regex string> is matched against the input string greedily and in the order they are listed in the BODY. If a match succeeds, then it will execute <code>. Within <code>, the following symbols are bound:
+A <pattern spec> has the following grammar:
+
+    <pattern spec> := <regex string>
+                    | (EAGER <regex string>)
+
+The EAGER option is defined below.
+
+The <regex string> is matched against the input string greedily and in the order they are listed in the BODY. When the longest match is found, assuming no EAGER declarations, it will execute <code>. Within <code>, the following symbols are bound:
 
     $1, $2, ..., $n: String match on (unnamed) register n
     $NAME          : String match on named register (?<NAME>...)
     $@             : Entire string match.
     $<, $>         : Start and end position of match.
 
-Generally, <code> should explicitly RETURN some token object for a semantic analyzer to examine. An explcit RETURN is needed.
+Generally, <code> should explicitly RETURN some token object for a semantic analyzer to examine. An explicit RETURN is needed. If no RETURN is provided, then the lexer will throw away the match and move on as if the lexer were called again. (This is most often used to ignore matches, like whitespace.)
 
 The <regex string> of the lexical action may use the names of the symbols defined in the <alias definition> forms. For example, given the alias definitions
 
@@ -147,47 +224,126 @@ The <regex string> of the lexical action may use the names of the symbols define
      (:ident \"[a-z]+\"))
 
 one can use {{INT}} and {{IDENT}} within the <regex string>s of the <lexical action>.
-"
+
+If the <pattern spec> uses EAGER, then the lexical action will \"short circuit\". The EAGER option states that if a match occurs on this pattern, <code> should be executed immediately, disregarding the \"longest match\" rule. This can be used for certain kinds of optimizations."
   (multiple-value-bind (definitions-and-patterns declarations doc-string)
       (alexandria:parse-body body :documentation t)
     (let* ((definitions (first definitions-and-patterns))
-           (patterns (loop :for (regex . code) :in (rest definitions-and-patterns)
+           (patterns (loop :for (pattern-spec . code) :in (rest definitions-and-patterns)
+                           :for (regex eager)
+                             := (typecase pattern-spec
+                                  (string
+                                   (list pattern-spec nil))
+                                  (list
+                                   (assert (and (= 2 (length pattern-spec))
+                                                (stringp (second pattern-spec))
+                                                (symbolp (first pattern-spec))
+                                                (string= "EAGER" (first pattern-spec)))
+                                           ()
+                                           "The pattern spec ~S should either be a ~
+                                             string or a list: (EAGER <string>)."
+                                           pattern-spec)
+                                   (list (second pattern-spec) t))
+                                  (t (error "Invalid pattern spec ~S for the lexer ~
+                                             definition ~S."
+                                            pattern-spec name)))
                            :for parse-tree := (let ((cl-ppcre:*allow-named-registers* t))
                                                 `(:SEQUENCE :START-ANCHOR
-                                                  ,(cl-ppcre:parse-string
-                                                    (fill-in-aliases definitions regex))))
+                                                            ,(cl-ppcre:parse-string
+                                                              (fill-in-aliases definitions regex))))
                            :collect (multiple-value-bind (num-regs names)
                                         (extract-registers parse-tree)
                                       (make-pattern :regex regex
+                                                    :short-circuit-p eager
                                                     :parse-tree parse-tree
                                                     :num-registers num-regs
                                                     :register-names names
                                                     :code code)))))
-      (alexandria:with-gensyms (continue-tag string start end)
+      (alexandria:with-gensyms (CONTINUE-TAG
+                                EXECUTE-TAG
+                                string start end
+                                max-match-length
+                                match-rule-index
+                                match-start
+                                match-end
+                                reg-starts
+                                reg-ends)
         `(defun ,name (,string &key ((:start ,start) 0) ((:end ,end) (length ,string)))
            ,@(alexandria:ensure-list doc-string)
            ,@declarations
-           (check-type ,start (integer 0) ":START must be a non-negative integer.")
-           (check-type ,end (integer 0) ":END must be a non-negative integer.")
+           (check-type ,string simple-string)
+           (check-type ,start non-negative-fixnum ":START must be a non-negative fixnum.")
+           (check-type ,end non-negative-fixnum ":END must be a non-negative fixnum.")
            (assert (<= ,start ,end) (,start ,end) ":END must be not be less than :START.")
            (lambda ()
              (block nil
-               (tagbody
-                  ,continue-tag
-                  ;; Have we finished matching string?
-                  (when (= ,start ,end)
-                    ;; Free STRING from closure to allow garbage
-                    ;; collection.
-                    (setq ,string nil)
-                    ;; Return NIL indicating generator is exhausted.
-                    (return nil))
-                  ;; Generate all pattern clauses.
-                  ,@(loop :for pat :in patterns
-                          :collect (generate-pattern pat continue-tag string start end))
-                  ;; Error clause: No match
-                  (cerror "Continue, returning NIL."
-                          'lexer-match-error
-                          :format-control "Couldn't find match at position ~D ~
-                                           within the lexer ~S."
-                          :format-arguments (list ,start ',name))
-                  nil))))))))
+               ;; Our lexer state.
+               (let ((,match-rule-index -1)
+                     (,max-match-length 0)
+                     (,match-start      0)
+                     (,match-end        0)
+                     (,reg-starts       #())
+                     (,reg-ends         #()))
+                 (declare (type fixnum ,match-rule-index)
+                          (type non-negative-fixnum ,max-match-length ,match-start ,match-end)
+                          (type vector ,reg-starts ,reg-ends))
+                 (tagbody
+                    ,CONTINUE-TAG
+                    ;; If we continued, we need to have the state
+                    ;; reset. We only need to reset the variables that
+                    ;; determine which rules can get fired.
+                    (setq ,match-rule-index -1
+                          ,max-match-length 0)
+                    ;; Have we finished matching string?
+                    (when (= ,start ,end)
+                      ;; Free STRING from closure to allow garbage
+                      ;; collection.
+                      (setq ,string nil)
+                      ;; Return NIL indicating generator is exhausted.
+                      (return nil))
+
+                    ;; In the following pattern matching clauses, if a
+                    ;; match happens, we record the longest match
+                    ;; along with who matched, recorded in the
+                    ;; variables MAX-MATCH-LENGTH and MATCH-RULE-INDEX
+                    ;; respectively.
+                    ;;
+                    ;; Generate all pattern clauses.
+                    ,@(loop :for i :from 0
+                            :for pat :in patterns
+                            :collect (generate-pattern-match-code
+                                      pat EXECUTE-TAG
+                                      string start end
+                                      match-start match-end
+                                      reg-starts reg-ends
+                                      max-match-length match-rule-index i))
+
+                    ,EXECUTE-TAG
+                    (case ,match-rule-index
+                      ;; Code for each of the cases.
+                      ,@(loop :for i :from 0
+                              :for pat :in patterns
+                              :collect `(,i
+                                         ;; Update our new start for
+                                         ;; the next round of
+                                         ;; matching.
+                                         (setq ,start ,match-end)
+                                         ;; Generate the code to
+                                         ;; execute for this rule.
+                                         ,(generate-pattern-execution-code
+                                           pat
+                                           string
+                                           match-start match-end
+                                           reg-starts reg-ends)
+                                         ;; Assuming the pattern code
+                                         ;; didn't exit, continue with
+                                         ;; the lex loop.
+                                         (go ,CONTINUE-TAG)))
+                      ;; Default code if nothing found.
+                      (otherwise
+                       (cerror "Continue, returning NIL."
+                               'lexer-match-error
+                               :format-control "Couldn't find match at position ~D ~
+                                                within the lexer ~S."
+                               :format-arguments (list ,start ',name))
+                       (return nil))))))))))))

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -1,0 +1,117 @@
+;;;; tests.lisp
+;;;;
+;;;; Author: Robert Smith
+
+(fiasco:define-test-package #:alexa-tests
+    (:use #:alexa)
+
+  ;; suite.lisp
+  (:export
+   #:run-alexa-tests))
+
+(in-package #:alexa-tests)
+
+(defun run-alexa-tests (&key (verbose nil) (headless nil))
+  "Run all ALEXA tests. If VERBOSE is T, print out lots of test info. If HEADLESS is T, disable interactive debugging and quit on completion."
+  ;; Bug in Fiasco commit fe89c0e924c22c667cc11c6fc6e79419fc7c1a8b
+  (setf fiasco::*test-run-standard-output* (make-broadcast-stream
+                                            *standard-output*))
+  (cond
+    ((null headless)
+     (run-package-tests :package ':alexa-tests
+                        :verbose verbose
+                        :describe-failures t
+                        :interactive t))
+    (t
+     (let ((successp (run-package-tests :package ':alexa-tests
+                                        :verbose t
+                                        :describe-failures t
+                                        :interactive nil)))
+       (uiop:quit (if successp 0 1))))))
+
+(defun lex-count (lex-closure)
+  (loop :with ntoks := 0
+        :for tok := (funcall lex-closure)
+        :while tok
+        :do (incf ntoks)
+        :finally (return ntoks)))
+
+(defun lex (lexer string)
+  (loop :with lex-closure := (funcall lexer string)
+        :for tok := (funcall lex-closure)
+        :while tok
+        :collect tok))
+
+(defun is-lex (lexer string expected-result)
+  (is (equal expected-result (lex lexer string))))
+
+(define-string-lexer simple-lexer
+  ()
+  ("\\s+" nil)
+  ("a" (return #\a))
+  ("b" (return #\b)))
+
+(deftest test-simple-lexer ()
+  "Test basic lexing functionality."
+  (is-lex #'simple-lexer "" '())
+  (is-lex #'simple-lexer "   " '())
+  (is-lex #'simple-lexer "a" '(#\a))
+  (is-lex #'simple-lexer "b" '(#\b))
+  (is-lex #'simple-lexer "ab" '(#\a #\b))
+  (is-lex #'simple-lexer " ab aaa bbb " '(#\a #\b #\a #\a #\a #\b #\b #\b)))
+
+(define-string-lexer alias-lexer
+  ((:num "\\d+"))
+  ("{{NUM}}" (return (parse-integer $@))))
+
+(deftest test-alias-lexer ()
+  "Test that the alias functionality seems to work."
+  (dotimes (i 101)
+    (is-lex #'alias-lexer (format nil "~D" i) (list i))))
+
+(define-string-lexer position-lexer
+  ()
+  ("\\s+" nil)
+  ("a+" (return (cons $< $>))))
+
+(deftest test-position-lexer ()
+  "Test that positions $< and $> are calculated correctly."
+  (is-lex #'position-lexer "a" '((0 . 1)))
+  (is-lex #'position-lexer " a" '((1 . 2)))
+  (is-lex #'position-lexer " a a a" '((1 . 2) (3 . 4) (5 . 6)))
+  (is-lex #'position-lexer "a aa aaa" '((0 . 1) (2 . 4) (5 . 8))))
+
+(alexa:define-string-lexer arith-lexer
+  ((:num "\\d+")
+   (:name "[A-Za-z][A-Za-z0-9_]*"))
+  ("pi"       (return pi))
+  ("{{NAME}}" (return $@))
+  ("{{NUM}}"  (return (parse-integer $@)))
+  ("[+*/-]"   (return (intern $@ :keyword)))
+  ("\\("      (return #\())
+  ("\\)"      (return #\)))
+  ("\\s+"     nil))
+
+(alexa:define-string-lexer arith-lexer-opt
+  ((:num "\\d+")
+   (:name "[A-Za-z][A-Za-z0-9_]*"))
+  ((eager "{{NUM}}")  (return (parse-integer $@)))
+  ((eager "[+*/-]")   (return (intern $@ :keyword)))
+  ((eager "\\(")      (return #\())
+  ((eager "\\)")      (return #\)))
+  ((eager "\\s+")     nil)
+  ("pi"               (return pi))
+  ((eager "{{NAME}}") (return $@)))
+
+(deftest test-arith-lexers ()
+  "Test that a more complicated lexer works, including EAGER."
+  (flet ((test (string result)
+           (is (is-lex #'arith-lexer string result))
+           (is (is-lex #'arith-lexer-opt string result))))
+    (test "a" '("a"))
+    (test "pi" (list pi))
+    (test "123" '(123))
+    (test "(  )" '(#\( #\)))
+    (test "+ - * /" '(:+ :- :* :/))
+    (test "a123 a 123" '("a123" "a" 123))
+    (test "pi pip pine pi_2" (list pi "pip" "pine" "pi_2"))))


### PR DESCRIPTION
This PR adds two major features:

1. It changes the matching rules to fire the longest match (as opposed to the earliest match).
2. It adds the ability for the user to specify matches should be _eager_, i.e., allow a match to short-circuit the longest-match process.

See the commits for detailed explanations.

Thanks to Corwin de Boor (@Strikeskids) for the suggestion to implement this.