### PR TITLE
add new error conditions

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -8,6 +8,11 @@
   (:export
    #:define-string-lexer                ; MACRO
    #:lexer-match-error                  ; CONDITION
+   #:lexer-match-error-lexer-name       ; READER
+   #:lexer-match-error-position         ; READER
+   #:no-match-error                     ; CONDITION
+   #:empty-match-error                  ; CONDITION
+   #:empty-match-error-pattern          ; READER
    )
   )
 

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -58,7 +58,18 @@
   (is-lex #'simple-lexer "a" '(#\a))
   (is-lex #'simple-lexer "b" '(#\b))
   (is-lex #'simple-lexer "ab" '(#\a #\b))
-  (is-lex #'simple-lexer " ab aaa bbb " '(#\a #\b #\a #\a #\a #\b #\b #\b)))
+  (is-lex #'simple-lexer " ab aaa bbb " '(#\a #\b #\a #\a #\a #\b #\b #\b))
+  (signals alexa:no-match-error
+    (lex #'simple-lexer "?")))
+
+(define-string-lexer empty-match-lexer
+  ()
+  ("" (return "goof")))
+
+(deftest test-empty-match-lexer ()
+  "Tests that empty matches don't loop forever."
+  (signals alexa:empty-match-error
+    (lex #'empty-match-lexer "a")))
 
 (define-string-lexer alias-lexer
   ((:num "\\d+"))


### PR DESCRIPTION
This adds `empty-match-error` for matches that will loop infinitely due to an empty match, as well as a reader `lexer-match-error-position` to get the position at which a lexing error occurred.