### PR TITLE
fix: leave the backslashes alone when subsituting a regex

### DIFF
--- a/src/alexa.lisp
+++ b/src/alexa.lisp
@@ -297,7 +297,7 @@
         (let ((substitution (lookup-alias (extract-name-from-match match))))
           (setf resulting-regex (cl-ppcre:regex-replace-all `(:sequence ,match)
                                                             resulting-regex
-                                                            substitution)))))))
+                                                            (list substitution))))))))
 
 (defun parse-pattern-spec (spec)
   "Parse a \"pattern spec\", the places of DEFINE-LEXER where regex patterns are specified. The current supported syntax is:

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -80,6 +80,15 @@
   (dotimes (i 101)
     (is-lex #'alias-lexer (format nil "~D" i) (list i))))
 
+(deftest regression-test-for-github-issue-9 ()
+  "Test that the alias functionality replaces the patterns correctly."
+  (macroexpand
+   `(define-string-lexer alias-lexer-bug/github-issue9
+      "This used to fail to compile the regex: Missing right bracket to close character class. at position 6"
+      ;; Same regex, copy-pasted
+      ((:string "\"(?:[^\"\\\\]|\\\\.)*\""))
+      ("{{STRING}}" (return (token :term $@))))))
+
 (define-string-lexer position-lexer
   ()
   ("\\s+" nil)


### PR DESCRIPTION
Closes #9 